### PR TITLE
Issue #58: Use DatetimeImmutable instead of Datetime

### DIFF
--- a/src/App/src/Common/Entity/AbstractEntity.php
+++ b/src/App/src/Common/Entity/AbstractEntity.php
@@ -9,7 +9,7 @@ use Api\App\Common\TimestampAwareTrait;
 use Api\App\Common\UuidAwareInterface;
 use Api\App\Common\UuidAwareTrait;
 use Api\App\Common\UuidOrderedTimeGenerator;
-use DateTime;
+use DateTimeImmutable;
 
 /**
  * Class AbstractEntity
@@ -26,8 +26,8 @@ abstract class AbstractEntity implements UuidAwareInterface, TimestampAwareInter
     public function __construct()
     {
         $this->uuid = UuidOrderedTimeGenerator::generateUuid();
-        $this->created = new DateTime('now');
-        $this->updated = new DateTime('now');
+        $this->created = new DateTimeImmutable('now');
+        $this->updated = new DateTimeImmutable('now');
     }
 
     /**

--- a/src/App/src/Common/TimestampAwareInterface.php
+++ b/src/App/src/Common/TimestampAwareInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Api\App\Common;
 
-use DateTime;
+use DateTimeImmutable;
 
 /**
  * Interface TimestampAwareInterface
@@ -13,14 +13,14 @@ use DateTime;
 interface TimestampAwareInterface
 {
     /**
-     * @return DateTime|null
+     * @return DateTimeImmutable|null
      */
-    public function getCreated(): DateTime;
+    public function getCreated(): DateTimeImmutable;
 
     /**
-     * @return DateTime|null
+     * @return DateTimeImmutable|null
      */
-    public function getUpdated(): ?DateTime;
+    public function getUpdated(): ?DateTimeImmutable;
 
     /**
      * Update internal timestamps

--- a/src/App/src/Common/TimestampAwareTrait.php
+++ b/src/App/src/Common/TimestampAwareTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Api\App\Common;
 
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
 use Exception;
 
@@ -20,14 +20,14 @@ trait TimestampAwareTrait
     private $dateFormat = 'Y-m-d H:i:s';
 
     /**
-     * @ORM\Column(name="created", type="datetime")
-     * @var DateTime
+     * @ORM\Column(name="created", type="datetime_immutable")
+     * @var DateTimeImmutable $created
      */
     protected $created;
 
     /**
-     * @ORM\Column(name="updated", type="datetime", nullable=true)
-     * @var DateTime
+     * @ORM\Column(name="updated", type="datetime_immutable", nullable=true)
+     * @var DateTimeImmutable $updated
      */
     protected $updated;
 
@@ -41,9 +41,9 @@ trait TimestampAwareTrait
     }
 
     /**
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getCreated(): DateTime
+    public function getCreated(): DateTimeImmutable
     {
         return $this->created;
     }
@@ -53,7 +53,7 @@ trait TimestampAwareTrait
      */
     public function getCreatedFormatted()
     {
-        if ($this->created instanceof DateTime) {
+        if ($this->created instanceof DateTimeImmutable) {
             return $this->created->format($this->dateFormat);
         }
 
@@ -61,9 +61,9 @@ trait TimestampAwareTrait
     }
 
     /**
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getUpdated(): ?DateTime
+    public function getUpdated(): ?DateTimeImmutable
     {
         return $this->updated;
     }
@@ -73,7 +73,7 @@ trait TimestampAwareTrait
      */
     public function getUpdatedFormatted()
     {
-        if ($this->updated instanceof DateTime) {
+        if ($this->updated instanceof DateTimeImmutable) {
             return $this->updated->format($this->dateFormat);
         }
 
@@ -86,11 +86,11 @@ trait TimestampAwareTrait
     public function touch()
     {
         try {
-            if (!($this->created instanceof DateTime)) {
-                $this->created = new DateTime('now');
+            if (!($this->created instanceof DateTimeImmutable)) {
+                $this->created = new DateTimeImmutable('now');
             }
 
-            $this->updated = new DateTime('now');
+            $this->updated = new DateTimeImmutable('now');
         } catch (Exception $exception) {
             #TODO save the error message
         }

--- a/src/User/src/Entity/UserResetPasswordEntity.php
+++ b/src/User/src/Entity/UserResetPasswordEntity.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Api\User\Entity;
 
 use Api\App\Common\Entity\AbstractEntity;
+use DateInterval;
 use DateTime;
+use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
+use Exception;
 use Laminas\Stdlib\ArraySerializableInterface;
 
 /**
@@ -33,8 +36,8 @@ class UserResetPasswordEntity extends AbstractEntity implements ArraySerializabl
     protected $user;
 
     /**
-     * @ORM\Column(name="expires", type="datetime", nullable=false)
-     * @var DateTime
+     * @ORM\Column(name="expires", type="datetime_immutable", nullable=false)
+     * @var DateTimeImmutable
      */
     protected $expires;
 
@@ -57,8 +60,9 @@ class UserResetPasswordEntity extends AbstractEntity implements ArraySerializabl
     {
         parent::__construct();
 
-        $this->expires = new DateTime();
-        $this->expires->add(new \DateInterval('P1D'));
+        $tomorrow = new DateTime();
+        $tomorrow->add(new DateInterval('P1D'));
+        $this->expires = DateTimeImmutable::createFromMutable($tomorrow);
     }
 
     /**
@@ -81,18 +85,18 @@ class UserResetPasswordEntity extends AbstractEntity implements ArraySerializabl
     }
 
     /**
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getExpires(): DateTime
+    public function getExpires(): DateTimeImmutable
     {
         return $this->expires;
     }
 
     /**
-     * @param DateTime $expires
+     * @param DateTimeImmutable $expires
      * @return $this
      */
-    public function setExpires(DateTime $expires)
+    public function setExpires(DateTimeImmutable $expires)
     {
         $this->expires = $expires;
 
@@ -155,8 +159,8 @@ class UserResetPasswordEntity extends AbstractEntity implements ArraySerializabl
     public function isValid(): bool
     {
         try {
-            return $this->getExpires() > (new DateTime());
-        } catch (\Exception $exception) {
+            return $this->getExpires() > (new DateTimeImmutable());
+        } catch (Exception $exception) {
         }
 
         return false;


### PR DESCRIPTION
**NOTE:**

This fix modifies the ORM type of properties `created` and `updated` on all entitites that `use TimestampAwareTrait`.
Their ORM type changes from `datetime` to `datetime_immutable`.
To avoid return type conflicts, Doctrine's entity cache must be emptied after applying this fix.

Also, make sure you check if your code expects these properties to return an instance of `DateTime` and change those to `DateTimeImmutable`.