### PR TITLE
Issue #6: Error log filename not correct

### DIFF
--- a/config/autoload/error-handling.global.php
+++ b/config/autoload/error-handling.global.php
@@ -16,10 +16,7 @@ return [
                         'name' => 'stream',
                         'priority' => Logger::ALERT,
                         'options' => [
-                            'stream' => sprintf('%s/../../log/error-log-%s.log',
-                                __DIR__,
-                                date('Y-m-d')
-                            ),
+                            'stream' => __DIR__ . '/../../log/error-log-{Y}-{m}-{d}.log',
                             // explicitly log all messages
                             'filters' => [
                                 'allMessages' => [


### PR DESCRIPTION
This fix requires usage of the latest [dot-log](https://github.com/dotkernel/dot-log) modifications, found [here](https://github.com/dotkernel/dot-log/pull/12).