### PR TITLE
Removed unused line from doctrine.global.php

### DIFF
--- a/config/autoload/doctrine.global.php
+++ b/config/autoload/doctrine.global.php
@@ -12,7 +12,7 @@ use Ramsey\Uuid\Doctrine\UuidBinaryType;
 use Ramsey\Uuid\Doctrine\UuidType;
 
 return [
-    'doctrine'            => [
+    'doctrine' => [
         'connection'    => [
             'orm_default' => [
                 'doctrine_mapping_types' => [

--- a/config/autoload/doctrine.global.php
+++ b/config/autoload/doctrine.global.php
@@ -79,5 +79,4 @@ return [
             ],
         ],
     ],
-    'resultCacheLifetime' => 3600,
 ];


### PR DESCRIPTION
Removed unused `resultCacheLifetime` line from doctrine.global.php.