### PR TITLE
Issue #313: Remove `config` dependency from handlers.

### DIFF
--- a/src/Admin/src/ConfigProvider.php
+++ b/src/Admin/src/ConfigProvider.php
@@ -11,7 +11,9 @@ use Api\Admin\Entity\Admin;
 use Api\Admin\Entity\AdminRole;
 use Api\Admin\Factory\AdminCreateCommandFactory;
 use Api\Admin\Handler\AdminAccountHandler;
+use Api\Admin\Handler\AdminCollectionHandler;
 use Api\Admin\Handler\AdminHandler;
+use Api\Admin\Handler\AdminRoleCollectionHandler;
 use Api\Admin\Handler\AdminRoleHandler;
 use Api\Admin\Repository\AdminRepository;
 use Api\Admin\Repository\AdminRoleRepository;
@@ -46,14 +48,16 @@ class ConfigProvider
                 ],
             ],
             'factories'  => [
-                AdminHandler::class        => AttributedServiceFactory::class,
-                AdminAccountHandler::class => AttributedServiceFactory::class,
-                AdminRoleHandler::class    => AttributedServiceFactory::class,
-                AdminService::class        => AttributedServiceFactory::class,
-                AdminRoleService::class    => AttributedServiceFactory::class,
-                AdminCreateCommand::class  => AdminCreateCommandFactory::class,
-                AdminRepository::class     => AttributedRepositoryFactory::class,
-                AdminRoleRepository::class => AttributedRepositoryFactory::class,
+                AdminHandler::class               => AttributedServiceFactory::class,
+                AdminCollectionHandler::class     => AttributedServiceFactory::class,
+                AdminAccountHandler::class        => AttributedServiceFactory::class,
+                AdminRoleHandler::class           => AttributedServiceFactory::class,
+                AdminRoleCollectionHandler::class => AttributedServiceFactory::class,
+                AdminService::class               => AttributedServiceFactory::class,
+                AdminRoleService::class           => AttributedServiceFactory::class,
+                AdminCreateCommand::class         => AdminCreateCommandFactory::class,
+                AdminRepository::class            => AttributedRepositoryFactory::class,
+                AdminRoleRepository::class        => AttributedRepositoryFactory::class,
             ],
             'aliases'    => [
                 AdminServiceInterface::class     => AdminService::class,

--- a/src/Admin/src/Handler/AdminAccountHandler.php
+++ b/src/Admin/src/Handler/AdminAccountHandler.php
@@ -26,13 +26,11 @@ class AdminAccountHandler implements RequestHandlerInterface
         HalResponseFactory::class,
         ResourceGenerator::class,
         AdminServiceInterface::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
         protected AdminServiceInterface $adminService,
-        protected array $config,
     ) {
     }
 

--- a/src/Admin/src/Handler/AdminCollectionHandler.php
+++ b/src/Admin/src/Handler/AdminCollectionHandler.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Api\Admin\Handler;
 
-use Api\Admin\Service\AdminRoleServiceInterface;
-use Api\App\Exception\NotFoundException;
+use Api\Admin\Service\AdminServiceInterface;
+use Api\App\Exception\BadRequestException;
 use Api\App\Handler\HandlerTrait;
 use Dot\DependencyInjection\Attribute\Inject;
 use Mezzio\Hal\HalResponseFactory;
@@ -14,29 +14,27 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class AdminRoleHandler implements RequestHandlerInterface
+class AdminCollectionHandler implements RequestHandlerInterface
 {
     use HandlerTrait;
 
     #[Inject(
         HalResponseFactory::class,
         ResourceGenerator::class,
-        AdminRoleServiceInterface::class,
+        AdminServiceInterface::class,
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
-        protected AdminRoleServiceInterface $roleService,
+        protected AdminServiceInterface $adminService,
     ) {
     }
 
     /**
-     * @throws NotFoundException
+     * @throws BadRequestException
      */
     public function get(ServerRequestInterface $request): ResponseInterface
     {
-        $role = $this->roleService->findOneBy(['uuid' => $request->getAttribute('uuid')]);
-
-        return $this->createResponse($request, $role);
+        return $this->createResponse($request, $this->adminService->getAdmins($request->getQueryParams()));
     }
 }

--- a/src/Admin/src/Handler/AdminHandler.php
+++ b/src/Admin/src/Handler/AdminHandler.php
@@ -26,13 +26,11 @@ class AdminHandler implements RequestHandlerInterface
         HalResponseFactory::class,
         ResourceGenerator::class,
         AdminServiceInterface::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
         protected AdminServiceInterface $adminService,
-        protected array $config,
     ) {
     }
 
@@ -56,14 +54,6 @@ class AdminHandler implements RequestHandlerInterface
         $admin = $this->adminService->findOneBy(['uuid' => $request->getAttribute('uuid')]);
 
         return $this->createResponse($request, $admin);
-    }
-
-    /**
-     * @throws BadRequestException
-     */
-    public function getCollection(ServerRequestInterface $request): ResponseInterface
-    {
-        return $this->createResponse($request, $this->adminService->getAdmins($request->getQueryParams()));
     }
 
     /**

--- a/src/Admin/src/Handler/AdminRoleCollectionHandler.php
+++ b/src/Admin/src/Handler/AdminRoleCollectionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Api\Admin\Handler;
 
 use Api\Admin\Service\AdminRoleServiceInterface;
-use Api\App\Exception\NotFoundException;
+use Api\App\Exception\BadRequestException;
 use Api\App\Handler\HandlerTrait;
 use Dot\DependencyInjection\Attribute\Inject;
 use Mezzio\Hal\HalResponseFactory;
@@ -14,7 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class AdminRoleHandler implements RequestHandlerInterface
+class AdminRoleCollectionHandler implements RequestHandlerInterface
 {
     use HandlerTrait;
 
@@ -31,12 +31,10 @@ class AdminRoleHandler implements RequestHandlerInterface
     }
 
     /**
-     * @throws NotFoundException
+     * @throws BadRequestException
      */
     public function get(ServerRequestInterface $request): ResponseInterface
     {
-        $role = $this->roleService->findOneBy(['uuid' => $request->getAttribute('uuid')]);
-
-        return $this->createResponse($request, $role);
+        return $this->createResponse($request, $this->roleService->getAdminRoles($request->getQueryParams()));
     }
 }

--- a/src/Admin/src/RoutesDelegator.php
+++ b/src/Admin/src/RoutesDelegator.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Api\Admin;
 
 use Api\Admin\Handler\AdminAccountHandler;
+use Api\Admin\Handler\AdminCollectionHandler;
 use Api\Admin\Handler\AdminHandler;
+use Api\Admin\Handler\AdminRoleCollectionHandler;
 use Api\Admin\Handler\AdminRoleHandler;
 use Mezzio\Application;
 use Psr\Container\ContainerInterface;
@@ -44,7 +46,7 @@ class RoutesDelegator
         );
         $app->get(
             '/admin',
-            AdminHandler::class,
+            AdminCollectionHandler::class,
             'admin.list'
         );
         $app->patch(
@@ -60,7 +62,7 @@ class RoutesDelegator
 
         $app->get(
             '/admin/role',
-            AdminRoleHandler::class,
+            AdminRoleCollectionHandler::class,
             'admin.role.list'
         );
         $app->get(

--- a/src/App/src/Handler/ErrorReportHandler.php
+++ b/src/App/src/Handler/ErrorReportHandler.php
@@ -26,13 +26,11 @@ class ErrorReportHandler implements RequestHandlerInterface
         HalResponseFactory::class,
         ResourceGenerator::class,
         ErrorReportServiceInterface::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
         protected ErrorReportServiceInterface $errorReportService,
-        protected array $config,
     ) {
     }
 

--- a/src/App/src/Handler/HandlerTrait.php
+++ b/src/App/src/Handler/HandlerTrait.php
@@ -13,19 +13,12 @@ use Api\App\Exception\NotFoundException;
 use Api\App\Exception\UnauthorizedException;
 use Dot\Mail\Exception\MailException;
 use Exception;
-use Fig\Http\Message\RequestMethodInterface;
 use Fig\Http\Message\StatusCodeInterface;
-use Mezzio\Hal\Metadata\MetadataMap;
-use Mezzio\Hal\Metadata\RouteBasedCollectionMetadata;
 use Mezzio\Hal\ResourceGenerator\Exception\OutOfBoundsException;
-use Mezzio\Router\RouteResult;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 
-use function array_key_exists;
-use function assert;
-use function is_array;
 use function method_exists;
 use function sprintf;
 use function strtolower;
@@ -41,10 +34,6 @@ trait HandlerTrait
     {
         try {
             $method = strtolower($request->getMethod());
-            if ($this->isGetCollectionRequest($request, $this->config)) {
-                $method = 'getCollection';
-            }
-
             if (! method_exists($this, $method)) {
                 throw new MethodNotAllowedException(
                     sprintf('Method %s is not implemented for the requested resource.', $method)
@@ -69,38 +58,5 @@ trait HandlerTrait
         } catch (MailException | RuntimeException | Exception $exception) {
             return $this->errorResponse($exception->getMessage());
         }
-    }
-
-    /**
-     * @throws RuntimeException
-     */
-    private function isGetCollectionRequest(ServerRequestInterface $request, array $config): bool
-    {
-        if ($request->getMethod() !== RequestMethodInterface::METHOD_GET) {
-            return false;
-        }
-
-        if (! array_key_exists(MetadataMap::class, $config)) {
-            throw new RuntimeException(
-                sprintf('Unable to load %s from config.', MetadataMap::class)
-            );
-        }
-
-        $routeResult = $request->getAttribute(RouteResult::class);
-        assert($routeResult instanceof RouteResult);
-
-        $routeName = $routeResult->getMatchedRouteName();
-
-        $halConfig = null;
-        foreach ($config[MetadataMap::class] as $cfg) {
-            if ($cfg['route'] === $routeName) {
-                $halConfig = $cfg;
-                break;
-            }
-        }
-
-        return is_array($halConfig)
-            && array_key_exists('__class__', $halConfig)
-            && $halConfig['__class__'] === RouteBasedCollectionMetadata::class;
     }
 }

--- a/src/App/src/Handler/HomeHandler.php
+++ b/src/App/src/Handler/HomeHandler.php
@@ -23,12 +23,10 @@ class HomeHandler implements RequestHandlerInterface
     #[Inject(
         HalResponseFactory::class,
         ResourceGenerator::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
-        protected array $config,
     ) {
     }
 

--- a/src/User/src/ConfigProvider.php
+++ b/src/User/src/ConfigProvider.php
@@ -18,7 +18,9 @@ use Api\User\Handler\AccountRecoveryHandler;
 use Api\User\Handler\AccountResetPasswordHandler;
 use Api\User\Handler\UserActivateHandler;
 use Api\User\Handler\UserAvatarHandler;
+use Api\User\Handler\UserCollectionHandler;
 use Api\User\Handler\UserHandler;
+use Api\User\Handler\UserRoleCollectionHandler;
 use Api\User\Handler\UserRoleHandler;
 use Api\User\Repository\UserAvatarRepository;
 use Api\User\Repository\UserDetailRepository;
@@ -67,7 +69,9 @@ class ConfigProvider
                 UserAvatarHandler::class           => AttributedServiceFactory::class,
                 UserAvatarEventListener::class     => AttributedServiceFactory::class,
                 UserHandler::class                 => AttributedServiceFactory::class,
+                UserCollectionHandler::class       => AttributedServiceFactory::class,
                 UserRoleHandler::class             => AttributedServiceFactory::class,
+                UserRoleCollectionHandler::class   => AttributedServiceFactory::class,
                 UserService::class                 => AttributedServiceFactory::class,
                 UserRoleService::class             => AttributedServiceFactory::class,
                 UserAvatarService::class           => AttributedServiceFactory::class,

--- a/src/User/src/Handler/AccountActivateHandler.php
+++ b/src/User/src/Handler/AccountActivateHandler.php
@@ -30,13 +30,11 @@ class AccountActivateHandler implements RequestHandlerInterface
         HalResponseFactory::class,
         ResourceGenerator::class,
         UserServiceInterface::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
         protected UserServiceInterface $userService,
-        protected array $config,
     ) {
     }
 

--- a/src/User/src/Handler/AccountAvatarHandler.php
+++ b/src/User/src/Handler/AccountAvatarHandler.php
@@ -26,13 +26,11 @@ class AccountAvatarHandler implements RequestHandlerInterface
         HalResponseFactory::class,
         ResourceGenerator::class,
         UserAvatarServiceInterface::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
         protected UserAvatarServiceInterface $userAvatarService,
-        protected array $config,
     ) {
     }
 

--- a/src/User/src/Handler/AccountHandler.php
+++ b/src/User/src/Handler/AccountHandler.php
@@ -29,13 +29,11 @@ class AccountHandler implements RequestHandlerInterface
         HalResponseFactory::class,
         ResourceGenerator::class,
         UserServiceInterface::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
         protected UserServiceInterface $userService,
-        protected array $config,
     ) {
     }
 

--- a/src/User/src/Handler/AccountRecoveryHandler.php
+++ b/src/User/src/Handler/AccountRecoveryHandler.php
@@ -26,13 +26,11 @@ class AccountRecoveryHandler implements RequestHandlerInterface
         HalResponseFactory::class,
         ResourceGenerator::class,
         UserServiceInterface::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
         protected UserServiceInterface $userService,
-        protected array $config,
     ) {
     }
 

--- a/src/User/src/Handler/AccountResetPasswordHandler.php
+++ b/src/User/src/Handler/AccountResetPasswordHandler.php
@@ -33,13 +33,11 @@ class AccountResetPasswordHandler implements RequestHandlerInterface
         HalResponseFactory::class,
         ResourceGenerator::class,
         UserServiceInterface::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
         protected UserServiceInterface $userService,
-        protected array $config,
     ) {
     }
 

--- a/src/User/src/Handler/UserActivateHandler.php
+++ b/src/User/src/Handler/UserActivateHandler.php
@@ -25,13 +25,11 @@ class UserActivateHandler implements RequestHandlerInterface
         HalResponseFactory::class,
         ResourceGenerator::class,
         UserServiceInterface::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
         protected UserServiceInterface $userService,
-        protected array $config,
     ) {
     }
 

--- a/src/User/src/Handler/UserAvatarHandler.php
+++ b/src/User/src/Handler/UserAvatarHandler.php
@@ -27,14 +27,12 @@ class UserAvatarHandler implements RequestHandlerInterface
         ResourceGenerator::class,
         UserServiceInterface::class,
         UserAvatarServiceInterface::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
         protected UserServiceInterface $userService,
         protected UserAvatarServiceInterface $userAvatarService,
-        protected array $config,
     ) {
     }
 

--- a/src/User/src/Handler/UserCollectionHandler.php
+++ b/src/User/src/Handler/UserCollectionHandler.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Api\Admin\Handler;
+namespace Api\User\Handler;
 
-use Api\Admin\Service\AdminRoleServiceInterface;
-use Api\App\Exception\NotFoundException;
+use Api\App\Exception\BadRequestException;
 use Api\App\Handler\HandlerTrait;
+use Api\User\Service\UserServiceInterface;
 use Dot\DependencyInjection\Attribute\Inject;
 use Mezzio\Hal\HalResponseFactory;
 use Mezzio\Hal\ResourceGenerator;
@@ -14,29 +14,27 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class AdminRoleHandler implements RequestHandlerInterface
+class UserCollectionHandler implements RequestHandlerInterface
 {
     use HandlerTrait;
 
     #[Inject(
         HalResponseFactory::class,
         ResourceGenerator::class,
-        AdminRoleServiceInterface::class,
+        UserServiceInterface::class,
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
-        protected AdminRoleServiceInterface $roleService,
+        protected UserServiceInterface $userService,
     ) {
     }
 
     /**
-     * @throws NotFoundException
+     * @throws BadRequestException
      */
     public function get(ServerRequestInterface $request): ResponseInterface
     {
-        $role = $this->roleService->findOneBy(['uuid' => $request->getAttribute('uuid')]);
-
-        return $this->createResponse($request, $role);
+        return $this->createResponse($request, $this->userService->getUsers($request->getQueryParams()));
     }
 }

--- a/src/User/src/Handler/UserHandler.php
+++ b/src/User/src/Handler/UserHandler.php
@@ -28,13 +28,11 @@ class UserHandler implements RequestHandlerInterface
         HalResponseFactory::class,
         ResourceGenerator::class,
         UserServiceInterface::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
         protected UserServiceInterface $userService,
-        protected array $config,
     ) {
     }
 
@@ -59,14 +57,6 @@ class UserHandler implements RequestHandlerInterface
         $user = $this->userService->findOneBy(['uuid' => $request->getAttribute('uuid')]);
 
         return $this->createResponse($request, $user);
-    }
-
-    /**
-     * @throws BadRequestException
-     */
-    public function getCollection(ServerRequestInterface $request): ResponseInterface
-    {
-        return $this->createResponse($request, $this->userService->getUsers($request->getQueryParams()));
     }
 
     /**

--- a/src/User/src/Handler/UserRoleCollectionHandler.php
+++ b/src/User/src/Handler/UserRoleCollectionHandler.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Api\Admin\Handler;
+namespace Api\User\Handler;
 
-use Api\Admin\Service\AdminRoleServiceInterface;
-use Api\App\Exception\NotFoundException;
+use Api\App\Exception\BadRequestException;
 use Api\App\Handler\HandlerTrait;
+use Api\User\Service\UserRoleServiceInterface;
 use Dot\DependencyInjection\Attribute\Inject;
 use Mezzio\Hal\HalResponseFactory;
 use Mezzio\Hal\ResourceGenerator;
@@ -14,29 +14,27 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class AdminRoleHandler implements RequestHandlerInterface
+class UserRoleCollectionHandler implements RequestHandlerInterface
 {
     use HandlerTrait;
 
     #[Inject(
         HalResponseFactory::class,
         ResourceGenerator::class,
-        AdminRoleServiceInterface::class,
+        UserRoleServiceInterface::class,
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
-        protected AdminRoleServiceInterface $roleService,
+        protected UserRoleServiceInterface $roleService,
     ) {
     }
 
     /**
-     * @throws NotFoundException
+     * @throws BadRequestException
      */
     public function get(ServerRequestInterface $request): ResponseInterface
     {
-        $role = $this->roleService->findOneBy(['uuid' => $request->getAttribute('uuid')]);
-
-        return $this->createResponse($request, $role);
+        return $this->createResponse($request, $this->roleService->getRoles($request->getQueryParams()));
     }
 }

--- a/src/User/src/Handler/UserRoleHandler.php
+++ b/src/User/src/Handler/UserRoleHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Api\User\Handler;
 
-use Api\App\Exception\BadRequestException;
 use Api\App\Exception\NotFoundException;
 use Api\App\Handler\HandlerTrait;
 use Api\User\Service\UserRoleServiceInterface;
@@ -23,13 +22,11 @@ class UserRoleHandler implements RequestHandlerInterface
         HalResponseFactory::class,
         ResourceGenerator::class,
         UserRoleServiceInterface::class,
-        "config",
     )]
     public function __construct(
         protected HalResponseFactory $responseFactory,
         protected ResourceGenerator $resourceGenerator,
         protected UserRoleServiceInterface $roleService,
-        protected array $config,
     ) {
     }
 
@@ -41,13 +38,5 @@ class UserRoleHandler implements RequestHandlerInterface
         $role = $this->roleService->findOneBy(['uuid' => $request->getAttribute('uuid')]);
 
         return $this->createResponse($request, $role);
-    }
-
-    /**
-     * @throws BadRequestException
-     */
-    public function getCollection(ServerRequestInterface $request): ResponseInterface
-    {
-        return $this->createResponse($request, $this->roleService->getRoles($request->getQueryParams()));
     }
 }

--- a/src/User/src/RoutesDelegator.php
+++ b/src/User/src/RoutesDelegator.php
@@ -11,7 +11,9 @@ use Api\User\Handler\AccountRecoveryHandler;
 use Api\User\Handler\AccountResetPasswordHandler;
 use Api\User\Handler\UserActivateHandler;
 use Api\User\Handler\UserAvatarHandler;
+use Api\User\Handler\UserCollectionHandler;
 use Api\User\Handler\UserHandler;
+use Api\User\Handler\UserRoleCollectionHandler;
 use Api\User\Handler\UserRoleHandler;
 use Mezzio\Application;
 use Psr\Container\ContainerInterface;
@@ -43,7 +45,7 @@ class RoutesDelegator
         );
         $app->get(
             '/user',
-            UserHandler::class,
+            UserCollectionHandler::class,
             'user.list'
         );
         $app->patch(
@@ -81,7 +83,7 @@ class RoutesDelegator
 
         $app->get(
             '/user/role',
-            UserRoleHandler::class,
+            UserRoleCollectionHandler::class,
             'user.role.list'
         );
         $app->get(


### PR DESCRIPTION
This implementation removes the dependency of `config` from all handlers.
It also introduces new handlers for collection related endpoints.

@cPintiuta @MarioRadu let me know your thoughts, if this implementation solves the issue described in #313 or I should look into other solutions.