### PR TITLE
Issue #331: Added `symfony/var-dumper` to the dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
         "mezzio/mezzio-tooling": "^2.9.0",
         "phpunit/phpunit": "^10.5.10",
         "roave/security-advisories": "dev-latest",
+        "symfony/var-dumper": "^7.1",
         "vimeo/psalm": "^5.22.0"
     },
     "autoload": {


### PR DESCRIPTION
I ended up adding `symfony/var-dumper` to `require-dev` instead of registering it as a suggestion, because it does not require any extra package besides what we already require, so it should be ok to have the package available as soon the projetc is installed.
Before requiring `var-dumper`, there were **164** dependencies in vendor, after, there are **165**.