### PR TITLE
Removed laminas/laminas-config package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,6 @@
         "dotkernel/dot-mail": "^4.1.1",
         "dotkernel/dot-response-header": "^3.2.3",
         "laminas/laminas-component-installer": "^3.4.0",
-        "laminas/laminas-config": "^3.9.0",
         "laminas/laminas-config-aggregator": "^1.14.0",
         "laminas/laminas-http": "^2.19.0",
         "laminas/laminas-hydrator": "^4.15.0",


### PR DESCRIPTION
We do not use the `laminas/laminas-config` package, `laminas/laminas-config-aggregator` requires it in dev mode.