### PR TITLE
fix(entity): explicitly set userId to null in OAuthAccessToken constructor

### DIFF
--- a/src/Core/src/Security/src/Entity/OAuthAccessToken.php
+++ b/src/Core/src/Security/src/Entity/OAuthAccessToken.php
@@ -36,7 +36,7 @@ class OAuthAccessToken implements AccessTokenEntityInterface
     private ClientEntityInterface $client;
 
     #[ORM\Column(name: 'user_id', type: 'string', length: 25, nullable: true)]
-    private ?string $userId;
+    private ?string $userId = null;
 
     /** @var non-empty-string $token */
     #[ORM\Column(name: 'token', type: 'string', length: 100)]
@@ -62,7 +62,6 @@ class OAuthAccessToken implements AccessTokenEntityInterface
     public function __construct()
     {
         $this->scopes = new ArrayCollection();
-        $this->userId = null;
     }
 
     public function setId(int $id): self

--- a/src/Core/src/Security/src/Entity/OAuthAccessToken.php
+++ b/src/Core/src/Security/src/Entity/OAuthAccessToken.php
@@ -62,6 +62,7 @@ class OAuthAccessToken implements AccessTokenEntityInterface
     public function __construct()
     {
         $this->scopes = new ArrayCollection();
+        $this->userId = null;
     }
 
     public function setId(int $id): self


### PR DESCRIPTION
<img width="1112" height="766" alt="image" src="https://github.com/user-attachments/assets/4840ef64-b1ec-456e-8fbd-00a1d5a8a451" />

When using grant_type=client_credentials, the userIdentifier is null.
This caused an error in OAuthAccessToken::getUserIdentifier():

Typed property Core\Security\Entity\OAuthAccessToken::$userId must not be accessed before initialization


To fix this, I updated OAuthAccessToken.php by explicitly initializing $userId to null in the __construct() method.