### PR TITLE
Update PostgreSQL host configuration

### DIFF
--- a/config/autoload/local.php.dist
+++ b/config/autoload/local.php.dist
@@ -16,7 +16,7 @@ $databases = [
         'table_prefix' => '',
     ],
     'postgresql' => [
-        'host'         => 'localhost',
+        'host'         => '127.0.0.1',
         'dbname'       => 'dotkernel',
         'user'         => '',
         'password'     => '',


### PR DESCRIPTION
Change PostgreSQL host from 'localhost' to '127.0.0.1'.

 Postgres accept localhost only for socket connections, only 127.0.01 can be configured for `md5` or `Ident` connections