### PR TITLE
Issue #487: Added security headers

### DIFF
--- a/config/autoload/response-header.global.php
+++ b/config/autoload/response-header.global.php
@@ -8,8 +8,16 @@ return [
          * Global headers - applied to all routes
          */
         '*' => [
-            'permissions-policy' => [
+            'permissions-policy'     => [
                 'value'     => 'interest-cohort=()',
+                'overwrite' => true,
+            ],
+            'X-Content-Type-Options' => [
+                'value'     => 'nosniff',
+                'overwrite' => true,
+            ],
+            'Referrer-Policy'        => [
+                'value'     => 'no-referrer',
                 'overwrite' => true,
             ],
         ],
@@ -17,11 +25,25 @@ return [
         /**
          * Route-specific headers
          */
-//        'route-name' => [
-//            'header-name' => [
-//                'value' => 'header-value',
-//                'overwrite' => true,
-//            ]
-//        ],
+        'security::generate-token' => [
+            'Cache-Control' => [
+                'value'     => 'no-store',
+                'overwrite' => true,
+            ],
+            'Pragma'        => [
+                'value'     => 'no-cache',
+                'overwrite' => true,
+            ],
+        ],
+        'security::refresh-token'  => [
+            'Cache-Control' => [
+                'value'     => 'no-store',
+                'overwrite' => true,
+            ],
+            'Pragma'        => [
+                'value'     => 'no-cache',
+                'overwrite' => true,
+            ],
+        ],
     ],
 ];


### PR DESCRIPTION
With this PR, the following headers are added:

to all responses:
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: no-referrer`

to `/security/generate-token` and `/security/refresh-token` only:
- `Cache-Control: no-store`
- `Pragma: no-cache` (This is the `HTTP 1.0`-specific equivalent of `Cache-Control` - usually these two headers are used together)