### PR TITLE
Issue #533: Make sure that `config/autoload/cors.local.php` exists after Composer i/u

### DIFF
--- a/bin/composer-post-install-script.php
+++ b/bin/composer-post-install-script.php
@@ -43,6 +43,11 @@ function getEnvironment(): string
  */
 $files = [
     [
+        'source'      => 'config/autoload/cors.local.php.dist',
+        'destination' => 'config/autoload/cors.local.php',
+        'environment' => [ENVIRONMENT_DEVELOPMENT, ENVIRONMENT_PRODUCTION],
+    ],
+    [
         'source'      => 'config/autoload/local.php.dist',
         'destination' => 'config/autoload/local.php',
         'environment' => [ENVIRONMENT_DEVELOPMENT, ENVIRONMENT_PRODUCTION],


### PR DESCRIPTION
## Note

That this way developers might miss [this warning](https://github.com/dotkernel/api/blob/7.0/config/autoload/cors.local.php.dist#L11).

That was the original reason why we did not open this up by default
so that the action of making an API publicly available is a deliberate action.